### PR TITLE
feat(tui): render AI replies as markdown and auto-copy text selections

### DIFF
--- a/src/commands/ai/index.ts
+++ b/src/commands/ai/index.ts
@@ -256,7 +256,7 @@ Today is ${new Date().toDateString()}. Do not accept questions that are not rela
     ctx.removeBlock(spinnerId);
 
     if (finalText) {
-      ctx.addBlock({ type: 'streaming', text: finalText });
+      ctx.addBlock({ type: 'markdown', text: finalText });
     } else {
       ctx.addBlock({ type: 'error', message: 'No response from the assistant. Try rephrasing your question.' });
     }

--- a/src/tui/DefaultContext.ts
+++ b/src/tui/DefaultContext.ts
@@ -17,6 +17,7 @@ export const defaultContext: CommandContext = {
     else if (b.type === 'info') console.log(b.message);
     else if (b.type === 'link') console.log('To view, go to:', b.url);
     else if (b.type === 'streaming') process.stdout.write(b.text);
+    else if (b.type === 'markdown') console.log(b.text);
     else if (b.type === 'event') console.log(b.event);
     else if (b.type === 'empty') console.log('No results found.');
     else if (b.type === 'help') console.log('Commands...');

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,5 +1,8 @@
 import { For, Show, createMemo, createSignal, onMount, untrack } from 'solid-js';
-import { render, useKeyboard } from '@opentui/solid';
+import { render, useKeyboard, useRenderer, useSelectionHandler } from '@opentui/solid';
+import { ToastViewport } from './components/Toast';
+import { showToast } from './toast';
+import { copyToClipboard } from './clipboard';
 import { Welcome } from './components/Welcome';
 import { InputBar } from './components/InputBar';
 import { HintRow } from './components/HintRow';
@@ -123,6 +126,15 @@ const App = () => {
     }
   };
 
+  const renderer = useRenderer();
+  useSelectionHandler((selection) => {
+    const text = selection.getSelectedText();
+    if (!text || text.trim().length === 0) return;
+    void copyToClipboard(text);
+    showToast('Copied to clipboard', { variant: 'success' });
+    renderer.clearSelection();
+  });
+
   useKeyboard((key) => {
     if (paletteVisible()) {
       const pool = untrack(palettePool);
@@ -211,11 +223,12 @@ const App = () => {
           selectedIndex={paletteIndex()}
           visible={paletteVisible()}
         />
+        <ToastViewport />
       </box>
     </TuiContextProvider>
   );
 };
 
 export const mountTuiApp = (): void => {
-  render(() => <App />, { exitOnCtrlC: true, targetFps: 30 });
+  render(() => <App />, { exitOnCtrlC: true, targetFps: 30, useMouse: true });
 };

--- a/src/tui/clipboard.ts
+++ b/src/tui/clipboard.ts
@@ -1,0 +1,54 @@
+import { spawn } from 'child_process';
+
+const OSC52_PREFIX = '\x1b]52;c;';
+const OSC52_SUFFIX = '\x07';
+
+const writeOsc52 = (text: string): boolean => {
+  try {
+    const b64 = Buffer.from(text, 'utf8').toString('base64');
+    process.stdout.write(`${OSC52_PREFIX}${b64}${OSC52_SUFFIX}`);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const trySpawn = (command: string, args: string[], text: string): Promise<boolean> =>
+  new Promise((resolve) => {
+    try {
+      const child = spawn(command, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+      let done = false;
+      const finish = (ok: boolean) => {
+        if (done) return;
+        done = true;
+        resolve(ok);
+      };
+      child.on('error', () => finish(false));
+      child.on('close', (code) => finish(code === 0));
+      child.stdin.on('error', () => finish(false));
+      child.stdin.end(text);
+      setTimeout(() => finish(false), 1000);
+    } catch {
+      resolve(false);
+    }
+  });
+
+const writeNative = async (text: string): Promise<boolean> => {
+  if (process.platform === 'darwin') {
+    return trySpawn('pbcopy', [], text);
+  }
+  if (process.platform === 'win32') {
+    return trySpawn('clip', [], text);
+  }
+  if (process.env.WAYLAND_DISPLAY) {
+    if (await trySpawn('wl-copy', [], text)) return true;
+  }
+  if (await trySpawn('xclip', ['-selection', 'clipboard'], text)) return true;
+  return trySpawn('xsel', ['--clipboard', '--input'], text);
+};
+
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  const osc = writeOsc52(text);
+  const native = await writeNative(text);
+  return osc || native;
+};

--- a/src/tui/components/Toast.tsx
+++ b/src/tui/components/Toast.tsx
@@ -1,0 +1,44 @@
+import { For, Show } from 'solid-js';
+import { useToasts } from '../toast';
+import { colors, glyphs } from '../theme';
+
+const variantColor = {
+  success: colors.success,
+  info: colors.info,
+  error: colors.error,
+} as const;
+
+const variantGlyph = {
+  success: glyphs.check,
+  info: glyphs.bullet,
+  error: glyphs.cross,
+} as const;
+
+export const ToastViewport = () => (
+  <Show when={useToasts().length > 0}>
+    <box
+      position="absolute"
+      top={1}
+      right={2}
+      flexDirection="column"
+      zIndex={1000}
+    >
+      <For each={useToasts()}>
+        {(toast) => (
+          <box
+            borderStyle="rounded"
+            borderColor={variantColor[toast.variant]}
+            backgroundColor={colors.brandBlack}
+            paddingLeft={1}
+            paddingRight={1}
+            flexDirection="row"
+            marginBottom={1}
+          >
+            <text fg={variantColor[toast.variant]}>{`${variantGlyph[toast.variant]} `}</text>
+            <text fg={colors.textPrimary}>{toast.message}</text>
+          </box>
+        )}
+      </For>
+    </box>
+  </Show>
+);

--- a/src/tui/components/blocks/Markdown.tsx
+++ b/src/tui/components/blocks/Markdown.tsx
@@ -1,0 +1,105 @@
+import { SyntaxStyle } from '@opentui/core';
+import { colors } from '../../theme';
+
+let cachedStyle: SyntaxStyle | null = null;
+
+const getMarkdownStyle = (): SyntaxStyle => {
+  if (cachedStyle) return cachedStyle;
+  cachedStyle = SyntaxStyle.fromStyles({
+    default: { fg: colors.textPrimary },
+
+    'markup.heading': { fg: colors.brandLime, bold: true },
+    'markup.heading.1': { fg: colors.brandLime, bold: true },
+    'markup.heading.2': { fg: colors.accentLime, bold: true },
+    'markup.heading.3': { fg: colors.accentSky, bold: true },
+    'markup.heading.4': { fg: colors.accentCyan, bold: true },
+    'markup.heading.5': { fg: colors.accentMagenta, bold: true },
+    'markup.heading.6': { fg: colors.textMuted, bold: true },
+
+    'markup.italic': { fg: colors.textPrimary, italic: true },
+    'markup.strong': { fg: colors.textPrimary, bold: true },
+    'markup.strikethrough': { fg: colors.textDim, dim: true },
+
+    'markup.raw': { fg: colors.accentLime, bg: colors.brandBlack },
+    'markup.raw.block': { fg: colors.textPrimary, bg: colors.brandBlack },
+
+    'markup.link': { fg: colors.info },
+    'markup.link.label': { fg: colors.info, underline: true },
+    'markup.link.url': { fg: colors.accentSky, underline: true },
+    'markup.link.bracket.close': { fg: colors.info },
+
+    'markup.list': { fg: colors.accentLime },
+    'markup.list.checked': { fg: colors.success },
+    'markup.list.unchecked': { fg: colors.textMuted },
+
+    'markup.quote': { fg: colors.textMuted, italic: true },
+
+    'punctuation.special': { fg: colors.textDim },
+    'punctuation.delimiter': { fg: colors.textDim },
+    'punctuation.bracket': { fg: colors.textDim },
+
+    keyword: { fg: colors.accentMagenta, bold: true },
+    'keyword.function': { fg: colors.accentMagenta, bold: true },
+    'keyword.return': { fg: colors.accentMagenta, bold: true },
+    'keyword.conditional': { fg: colors.accentMagenta, bold: true },
+    'keyword.conditional.ternary': { fg: colors.accentMagenta },
+    'keyword.repeat': { fg: colors.accentMagenta, bold: true },
+    'keyword.exception': { fg: colors.error },
+    'keyword.import': { fg: colors.accentMagenta, bold: true },
+    'keyword.modifier': { fg: colors.accentMagenta },
+    'keyword.operator': { fg: colors.accentMagenta },
+    'keyword.coroutine': { fg: colors.accentMagenta },
+    'keyword.type': { fg: colors.accentSky },
+    'keyword.directive': { fg: colors.accentMagenta },
+
+    string: { fg: colors.brandLime },
+    'string.escape': { fg: colors.accentAmber },
+    'string.regexp': { fg: colors.accentAmber },
+    'string.special': { fg: colors.accentAmber },
+    'string.special.url': { fg: colors.info, underline: true },
+
+    number: { fg: colors.accentAmber },
+    boolean: { fg: colors.accentAmber, bold: true },
+
+    function: { fg: colors.accentSky },
+    'function.call': { fg: colors.accentSky },
+    'function.method': { fg: colors.accentSky },
+    'function.method.call': { fg: colors.accentSky },
+    'function.builtin': { fg: colors.accentCyan },
+
+    constructor: { fg: colors.accentSky, bold: true },
+
+    constant: { fg: colors.accentAmber },
+    'constant.builtin': { fg: colors.accentAmber, bold: true },
+
+    variable: { fg: colors.textPrimary },
+    'variable.builtin': { fg: colors.accentCyan, italic: true },
+    'variable.member': { fg: colors.textPrimary },
+    'variable.parameter': { fg: colors.accentLime, italic: true },
+
+    type: { fg: colors.accentSky },
+    'type.builtin': { fg: colors.accentSky, italic: true },
+
+    property: { fg: colors.textPrimary },
+    attribute: { fg: colors.accentLime },
+    module: { fg: colors.accentCyan },
+    'module.builtin': { fg: colors.accentCyan, italic: true },
+    label: { fg: colors.accentAmber },
+    operator: { fg: colors.textMuted },
+    comment: { fg: colors.textDim, italic: true },
+    'comment.documentation': { fg: colors.textDim, italic: true },
+
+    'character.special': { fg: colors.accentMagenta },
+    embedded: { fg: colors.textPrimary },
+  });
+  return cachedStyle;
+};
+
+export const Markdown = (props: { text: string; streaming?: boolean }) => (
+  <markdown
+    content={props.text}
+    syntaxStyle={getMarkdownStyle()}
+    streaming={props.streaming ?? false}
+    fg={colors.textPrimary}
+  />
+);

--- a/src/tui/components/blocks/index.tsx
+++ b/src/tui/components/blocks/index.tsx
@@ -15,6 +15,7 @@ import { Help } from './Help';
 import { InlineInput } from './InlineInput';
 import { InlineSelect } from './InlineSelect';
 import { Confirm } from './Confirm';
+import { Markdown } from './Markdown';
 
 type Variant<T extends BlockType['type']> = Extract<BlockType, { type: T }>;
 
@@ -41,6 +42,11 @@ export const renderBlock = (block: BlockType) => (
     </Match>
     <Match when={block.type === 'streaming' && block}>
       {(b: () => Variant<'streaming'>) => <Streaming text={b().text} />}
+    </Match>
+    <Match when={block.type === 'markdown' && block}>
+      {(b: () => Variant<'markdown'>) => (
+        <Markdown text={b().text} streaming={b().streaming} />
+      )}
     </Match>
     <Match when={block.type === 'table' && block}>
       {(b: () => Variant<'table'>) => (

--- a/src/tui/toast.ts
+++ b/src/tui/toast.ts
@@ -1,0 +1,39 @@
+import { createSignal } from 'solid-js';
+
+export type ToastVariant = 'success' | 'info' | 'error';
+
+export type Toast = {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+};
+
+const [toasts, setToasts] = createSignal<Toast[]>([]);
+let nextId = 1;
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+export const useToasts = toasts;
+
+export const dismissToast = (id: number): void => {
+  const t = timers.get(id);
+  if (t) {
+    clearTimeout(t);
+    timers.delete(id);
+  }
+  setToasts((prev) => prev.filter((toast) => toast.id !== id));
+};
+
+export const showToast = (
+  message: string,
+  options: { variant?: ToastVariant; durationMs?: number } = {},
+): number => {
+  const id = nextId++;
+  const variant = options.variant ?? 'success';
+  const durationMs = options.durationMs ?? 2000;
+  setToasts((prev) => [...prev, { id, message, variant }]);
+  if (durationMs > 0) {
+    const handle = setTimeout(() => dismissToast(id), durationMs);
+    timers.set(id, handle);
+  }
+  return id;
+};

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -15,6 +15,7 @@ export type BlockVariant =
   | { type: 'link'; text: string; url: string }
   | { type: 'empty' }
   | { type: 'streaming'; text: string }
+  | { type: 'markdown'; text: string; streaming?: boolean }
   | { type: 'event'; event: any }
   | { type: 'help' }
   | { type: 'inline-input'; label: string; secure?: boolean; onSubmit: (val: string) => void }


### PR DESCRIPTION
## Summary

- **Markdown rendering** for AI assistant replies. Adds a `markdown` block variant rendered via opentui's built-in `<markdown>` renderable, themed with a `SyntaxStyle` mapped to the brand tokens in `theme.ts`. Covers markdown markup (headings, lists, links, blockquotes, emphasis, inline + fenced code) **and** the JS/TS tree-sitter scopes (`keyword`, `string`, `function`, `type`, `comment`, etc.) so fenced code blocks render with proper syntax highlighting.
- **Auto-copy on mouse selection**. `useSelectionHandler` listens for opentui's drag-end selection event; the selected text is copied via OSC52 plus a native `pbcopy`/`clip`/`wl-copy`/`xclip`/`xsel` fallback, and a lightweight toast viewport pinned to the top-right shows "Copied to clipboard".

## Changes

- `src/tui/types.ts` — new `{ type: 'markdown'; text; streaming? }` block variant.
- `src/tui/components/blocks/Markdown.tsx` — new component wrapping opentui's `<markdown>` with a cached themed `SyntaxStyle`.
- `src/tui/components/blocks/index.tsx` — dispatcher arm for the new variant.
- `src/commands/ai/index.ts` — AI final reply now flows through `markdown` instead of `streaming` (plain text).
- `src/tui/DefaultContext.ts` — non-TTY fallback prints the raw markdown text.
- `src/tui/toast.ts` + `src/tui/components/Toast.tsx` — module-scoped toast store and absolute-positioned viewport.
- `src/tui/clipboard.ts` — OSC52 + cross-platform native clipboard helper.
- `src/tui/app.tsx` — wires `useSelectionHandler` to copy + toast on drag-end; mounts `ToastViewport`; enables `useMouse` explicitly in the renderer config.

## Test plan

- Run `/ai <question>` — verify the response renders with headings, lists, inline code, and syntax-highlighted fenced code blocks.
- Drag-select any text inside the TUI — verify the "Copied to clipboard" toast appears top-right and the clipboard contains the selected text.
- Pipe a command (e.g. `dodo products list 1`) in a non-TTY context — verify markdown blocks fall back to plain stdout output.