### PR TITLE
fix: TUI lifecycle, headless webhook commands and usage errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Manage your [Dodo Payments](https://dodopayments.com/) resources, test webhooks,
 
 - **Interactive TUI** — launch `dodo` with no arguments to open the full interactive interface with command palette, history, and live notifications.
 - **AI assistant built in** — ask questions or take actions in plain English with `/ai`. No extra setup, runs `dodopayments-mcp` locally.
-- **Secure by default** — API keys are stored in your OS secret store (macOS Keychain, Windows Credential Vault, Linux libsecret). No plaintext config on disk.
+- **Encrypted at rest** — API keys are stored in `~/.dodopayments/config.json`, AES-256-GCM encrypted with a machine-derived key. No plaintext credentials on disk.
 - **Auto update** — the CLI checks for new versions and notifies you in-app. Run `/update` to upgrade in place.
 - **Webhook tooling** — listen for live webhooks or trigger payloads offline for local development.
 
@@ -103,9 +103,9 @@ The login flow will:
 1. Open your browser to the Dodo Payments API Keys page.
 2. Prompt you to paste your API Key.
 3. Ask you to select an environment — **Test Mode** or **Live Mode**.
-4. Store the credentials in your OS secret store (Keychain on macOS, Credential Vault on Windows, libsecret on Linux).
+4. Store the credentials encrypted at `~/.dodopayments/config.json` (AES-256-GCM, machine-bound key).
 
-> **Heads up:** Because we use the OS secret store, you may be prompted for your **device password** the first time the CLI reads or writes credentials. If you're upgrading from an older version, any existing plaintext API key will be **migrated to the secret store and the legacy file deleted** automatically.
+> **Upgrading from v3.0.x?** Your previous keychain-stored credentials won't carry over — just run `dodo login` once to re-authenticate.
 
 ### Switching modes / logging out
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ For example:
 
 ```bash
 dodo payments list 1
-dodo customers create
-dodo wh trigger
+dodo customers list
+dodo wh trigger payment.success http://localhost:3000/webhook
 ```
 
-The reference tables below show every command. In the TUI, prefix them with `/`; in direct mode, drop the `/`.
+The reference tables below show every command. In the TUI, prefix them with `/`; in direct mode, drop the `/`. Commands marked `(TUI only)` are interactive wizards and only work inside the TUI.
 
 ---
 
@@ -198,16 +198,16 @@ The assistant respects your active environment (Test / Live).
 | Command | Description |
 | --- | --- |
 | `/customers list <page>` | List customers |
-| `/customers create` | Create a new customer |
-| `/customers update <id>` | Update an existing customer |
+| `/customers create` | Create a new customer (TUI only) |
+| `/customers update <id>` | Update an existing customer (TUI only) |
 
 ### Discounts
 
 | Command | Description |
 | --- | --- |
 | `/discounts list <page>` | List discounts |
-| `/discounts create` | Create a new percentage-based discount |
-| `/discounts delete <id>` | Remove a discount by ID |
+| `/discounts create` | Create a new percentage-based discount (TUI only) |
+| `/discounts delete <id>` | Remove a discount by ID (TUI only) |
 
 ### Licenses
 
@@ -234,7 +234,7 @@ The assistant respects your active environment (Test / Live).
 
 | Command | Description |
 | --- | --- |
-| `/checkout new` | Interactively create a hosted checkout session and get a payment link |
+| `/checkout new` | Interactively create a hosted checkout session and get a payment link (TUI only) |
 
 ### Webhooks
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,12 @@ Manage and test webhooks directly from the CLI.
 
 | Command | Description |
 | --- | --- |
-| `/wh listen` | Listen for webhooks in real time and forward them to your local dev server |
-| `/wh trigger` | Trigger a test webhook event interactively — even while logged out |
+| `/wh listen <url>` | Listen for webhooks in real time and forward them to `<url>` |
+| `/wh trigger <event> <url>` | Trigger a test webhook event offline — even while logged out |
 
-The `/wh trigger` flow guides you through:
+In the TUI, omitting the args (`/wh listen` or `/wh trigger`) opens an interactive wizard. In direct mode (`dodo wh …`), both arguments are required.
+
+The interactive `/wh trigger` flow guides you through:
 
 1. Setting a destination **endpoint URL**
 2. Selecting a specific **event** to trigger

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "ai": "^6.0.168",
         "chalk": "^5.6.2",
         "dodopayments": "^2.19.0",
-        "keytar": "^7.9.0",
+        "node-machine-id": "^1.1.12",
         "open": "^11.0.0",
         "solid-js": "^1.9.12",
       },
@@ -159,19 +159,13 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
@@ -188,8 +182,6 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -209,10 +201,6 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
     "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
@@ -220,8 +208,6 @@
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
@@ -236,8 +222,6 @@
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -256,8 +240,6 @@
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -279,8 +261,6 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -292,8 +272,6 @@
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
@@ -311,11 +289,7 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -349,8 +323,6 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "keytar": ["keytar@7.9.0", "", { "dependencies": { "node-addon-api": "^4.3.0", "prebuild-install": "^7.0.1" } }, "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ=="],
-
     "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -367,25 +339,15 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
     "minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
 
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "node-abi": ["node-abi@3.91.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg=="],
-
-    "node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
+    "node-machine-id": ["node-machine-id@1.1.12", "", {}, "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="],
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
@@ -427,21 +389,13 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -454,8 +408,6 @@
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -483,10 +435,6 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
     "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
@@ -495,21 +443,11 @@
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -520,8 +458,6 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -542,8 +478,6 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
-
-    "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ai": "^6.0.168",
     "chalk": "^5.6.2",
     "dodopayments": "^2.19.0",
-    "keytar": "^7.9.0",
+    "node-machine-id": "^1.1.12",
     "open": "^11.0.0",
     "solid-js": "^1.9.12"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -10,7 +10,7 @@
  * After bundling, we inject a tiny Node-compatible prelude that re-execs
  * the bundle under Bun if it's launched by Node. This is required because
  * `target: 'bun'` emits Bun-only runtime APIs (e.g. `import.meta.require`)
- * and our native deps (@opentui/core, keytar) load through Bun's loader.
+ * and our native deps (@opentui/core) load through Bun's loader.
  *
  * Without this prelude, `bun install -g dodopayments-cli` works on disk
  * but the symlinked `dodo` binary is invoked via `#!/usr/bin/env node`,
@@ -28,7 +28,6 @@ const result = await Bun.build({
   target: 'bun',
   minify: true,
   plugins: [solidPlugin],
-  external: ['keytar'],
 });
 
 if (!result.success) {

--- a/src/commands/addons/index.ts
+++ b/src/commands/addons/index.ts
@@ -4,6 +4,7 @@ import { currencyToSymbolMap } from '../../utils/currency-to-symbol-map';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleAddons(
   client: DodoPayments,
@@ -90,6 +91,6 @@ export async function handleAddons(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'addons', subCommand);
   }
 }

--- a/src/commands/checkout/index.ts
+++ b/src/commands/checkout/index.ts
@@ -1,6 +1,7 @@
 import DodoPayments from 'dodopayments';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleCheckout(
   client: DodoPayments,
@@ -70,6 +71,6 @@ export async function handleCheckout(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'checkout', subCommand);
   }
 }

--- a/src/commands/customers/index.ts
+++ b/src/commands/customers/index.ts
@@ -2,6 +2,7 @@ import DodoPayments from 'dodopayments';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleCustomers(
   client: DodoPayments,
@@ -132,6 +133,6 @@ export async function handleCustomers(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'customers', subCommand);
   }
 }

--- a/src/commands/discounts/index.ts
+++ b/src/commands/discounts/index.ts
@@ -2,6 +2,7 @@ import DodoPayments from 'dodopayments';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleDiscounts(
   client: DodoPayments,
@@ -115,6 +116,6 @@ export async function handleDiscounts(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'discounts', subCommand);
   }
 }

--- a/src/commands/discounts/index.ts
+++ b/src/commands/discounts/index.ts
@@ -93,7 +93,6 @@ export async function handleDiscounts(
       ctx.addBlock({ type: 'error', message: 'Discount ID required. Usage: /discounts delete <id>' });
       return;
     }
-
     const confirmed = await ctx.promptConfirm(`Delete discount ${discount_id}?`);
     if (!confirmed) {
       ctx.addBlock({ type: 'error', message: 'Deletion cancelled.' });

--- a/src/commands/licences/index.ts
+++ b/src/commands/licences/index.ts
@@ -2,6 +2,7 @@ import DodoPayments from 'dodopayments';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleLicences(
   client: DodoPayments,
@@ -37,6 +38,6 @@ export async function handleLicences(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'licences', subCommand);
   }
 }

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -1,17 +1,46 @@
 import DodoPayments from 'dodopayments';
 import open from 'open';
-import { saveConfig } from '../../utils/auth';
+import { saveConfig, type Mode } from '../../utils/auth';
 import type { CommandContext } from '../../tui/CommandContext';
 
-export async function handleLogin(ctx: CommandContext): Promise<boolean> {
-  await open('https://app.dodopayments.com/developer/api-keys');
+const USAGE = 'Usage: dodo login <api-key> <test|live>';
 
-  const apiKey = await ctx.promptInput('API key');
+function normalizeMode(value: string): Mode | null {
+  if (value === 'test' || value === 'test_mode') return 'test_mode';
+  if (value === 'live' || value === 'live_mode') return 'live_mode';
+  return null;
+}
 
-  const mode = (await ctx.promptSelect('Environment', [
-    { label: 'Test Mode', value: 'test_mode' },
-    { label: 'Live Mode', value: 'live_mode' },
-  ])) as 'test_mode' | 'live_mode';
+export async function handleLogin(
+  ctx: CommandContext,
+  apiKeyArg?: string,
+  modeArg?: string,
+): Promise<boolean> {
+  let apiKey: string;
+  let mode: Mode;
+
+  if (ctx.invocation === 'cli') {
+    if (!apiKeyArg || !modeArg) {
+      ctx.addBlock({ type: 'error', message: 'API key and mode are required.' });
+      ctx.addBlock({ type: 'info', message: USAGE });
+      return false;
+    }
+    const normalized = normalizeMode(modeArg);
+    if (!normalized) {
+      ctx.addBlock({ type: 'error', message: `Invalid mode '${modeArg}'. Use 'test' or 'live'.` });
+      ctx.addBlock({ type: 'info', message: USAGE });
+      return false;
+    }
+    apiKey = apiKeyArg;
+    mode = normalized;
+  } else {
+    await open('https://app.dodopayments.com/developer/api-keys');
+    apiKey = await ctx.promptInput('API key');
+    mode = (await ctx.promptSelect('Environment', [
+      { label: 'Test Mode', value: 'test_mode' },
+      { label: 'Live Mode', value: 'live_mode' },
+    ])) as Mode;
+  }
 
   const client = new DodoPayments({ bearerToken: apiKey, environment: mode });
 

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -3,7 +3,7 @@ import open from 'open';
 import { saveConfig } from '../../utils/auth';
 import type { CommandContext } from '../../tui/CommandContext';
 
-export async function handleLogin(ctx: CommandContext): Promise<void> {
+export async function handleLogin(ctx: CommandContext): Promise<boolean> {
   await open('https://app.dodopayments.com/developer/api-keys');
 
   const apiKey = await ctx.promptInput('API key');
@@ -27,9 +27,10 @@ export async function handleLogin(ctx: CommandContext): Promise<void> {
       message: 'Authentication failed. Check your API key and selected environment.',
     });
     process.exitCode = 1;
-    return;
+    return false;
   }
 
   await saveConfig(mode, apiKey);
   ctx.addBlock({ type: 'success', message: 'Setup complete.' });
+  return true;
 }

--- a/src/commands/logout/index.ts
+++ b/src/commands/logout/index.ts
@@ -51,5 +51,5 @@ export async function handleLogout(ctx: CommandContext, exit?: () => void): Prom
   }
 
   ctx.addBlock({ type: 'success', message: `Logged out from ${modeLabels[target]}.` });
-  process.exit(0);
+  exitCli();
 }

--- a/src/commands/logout/index.ts
+++ b/src/commands/logout/index.ts
@@ -8,7 +8,9 @@ const modeLabels: Record<Exclude<LogoutChoice, 'all'>, string> = {
   live_mode: 'Live Mode',
 };
 
-export async function handleLogout(ctx: CommandContext): Promise<void> {
+export async function handleLogout(ctx: CommandContext, exit?: () => void): Promise<void> {
+  const exitCli = exit ?? (() => process.exit(0));
+
   const target = await ctx.promptSelect('Sign out from', [
     { label: 'All accounts', value: 'all' },
     { label: 'Test Mode', value: 'test_mode' },
@@ -26,25 +28,25 @@ export async function handleLogout(ctx: CommandContext): Promise<void> {
 
   if (result.hadInvalidConfig) {
     ctx.addBlock({ type: 'error', message: 'Stored credentials were invalid and have been cleared.' });
-    process.exit(0);
+    exitCli();
     return;
   }
 
   if (target === 'all') {
     if (result.removedModes.length === 0) {
       ctx.addBlock({ type: 'error', message: 'No stored accounts found.' });
-      process.exit(0);
+      exitCli();
       return;
     }
 
     ctx.addBlock({ type: 'success', message: 'Logged out from all accounts.' });
-    process.exit(0);
+    exitCli();
     return;
   }
 
   if (result.removedModes.length === 0) {
     ctx.addBlock({ type: 'error', message: `No ${modeLabels[target]} account is signed in.` });
-    process.exit(0);
+    exitCli();
     return;
   }
 

--- a/src/commands/logout/index.ts
+++ b/src/commands/logout/index.ts
@@ -8,20 +8,50 @@ const modeLabels: Record<Exclude<LogoutChoice, 'all'>, string> = {
   live_mode: 'Live Mode',
 };
 
-export async function handleLogout(ctx: CommandContext, exit?: () => void): Promise<void> {
+const USAGE = 'Usage: dodo logout <test|live|all>';
+
+function normalizeTarget(value: string): LogoutChoice | null {
+  if (value === 'all') return 'all';
+  if (value === 'test' || value === 'test_mode') return 'test_mode';
+  if (value === 'live' || value === 'live_mode') return 'live_mode';
+  return null;
+}
+
+export async function handleLogout(
+  ctx: CommandContext,
+  exit?: () => void,
+  targetArg?: string,
+): Promise<void> {
   const exitCli = exit ?? (() => process.exit(0));
 
-  const target = await ctx.promptSelect('Sign out from', [
-    { label: 'All accounts', value: 'all' },
-    { label: 'Test Mode', value: 'test_mode' },
-    { label: 'Live Mode', value: 'live_mode' },
-  ]) as LogoutChoice;
+  let target: LogoutChoice;
 
-  const targetLabel = target === 'all' ? 'all accounts' : modeLabels[target];
-  const confirmed = await ctx.promptConfirm(`Sign out from ${targetLabel}?`);
-  if (!confirmed) {
-    ctx.addBlock({ type: 'error', message: 'Logout cancelled.' });
-    return;
+  if (ctx.invocation === 'cli') {
+    if (!targetArg) {
+      ctx.addBlock({ type: 'error', message: 'Target is required.' });
+      ctx.addBlock({ type: 'info', message: USAGE });
+      return;
+    }
+    const normalized = normalizeTarget(targetArg);
+    if (!normalized) {
+      ctx.addBlock({ type: 'error', message: `Invalid target '${targetArg}'. Use 'test', 'live', or 'all'.` });
+      ctx.addBlock({ type: 'info', message: USAGE });
+      return;
+    }
+    target = normalized;
+  } else {
+    target = (await ctx.promptSelect('Sign out from', [
+      { label: 'All accounts', value: 'all' },
+      { label: 'Test Mode', value: 'test_mode' },
+      { label: 'Live Mode', value: 'live_mode' },
+    ])) as LogoutChoice;
+
+    const targetLabel = target === 'all' ? 'all accounts' : modeLabels[target];
+    const confirmed = await ctx.promptConfirm(`Sign out from ${targetLabel}?`);
+    if (!confirmed) {
+      ctx.addBlock({ type: 'error', message: 'Logout cancelled.' });
+      return;
+    }
   }
 
   const result = await clearConfig(target);

--- a/src/commands/payments/index.ts
+++ b/src/commands/payments/index.ts
@@ -3,6 +3,7 @@ import { currencyToSymbolMap } from '../../utils/currency-to-symbol-map';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handlePayments(
   client: DodoPayments,
@@ -91,6 +92,6 @@ export async function handlePayments(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'payments', subCommand);
   }
 }

--- a/src/commands/products/index.ts
+++ b/src/commands/products/index.ts
@@ -5,6 +5,7 @@ import { currencyToSymbolMap } from '../../utils/currency-to-symbol-map';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleProducts(
   client: DodoPayments,
@@ -104,6 +105,6 @@ export async function handleProducts(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'products', subCommand);
   }
 }

--- a/src/commands/refund/index.ts
+++ b/src/commands/refund/index.ts
@@ -3,6 +3,7 @@ import { currencyToSymbolMap } from '../../utils/currency-to-symbol-map';
 import { isDodoPaymentsAPIError } from '../../utils/error';
 import { paginationTip } from '../../utils/tips';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 export async function handleRefund(
   client: DodoPayments,
@@ -81,6 +82,6 @@ export async function handleRefund(
       }
     }
   } else {
-    ctx.addBlock({ type: 'help' });
+    unknownSubcommand(ctx, 'refunds', subCommand);
   }
 }

--- a/src/commands/webhook/index.ts
+++ b/src/commands/webhook/index.ts
@@ -29,7 +29,7 @@ export async function handleWebhook(
       });
       break;
     case 'trigger':
-      await handleWebhookTrigger(ctx);
+      await handleWebhookTrigger(ctx, extraArgs);
       break;
     default:
       ctx.addBlock({ type: 'help' });

--- a/src/commands/webhook/index.ts
+++ b/src/commands/webhook/index.ts
@@ -12,6 +12,7 @@ export async function handleWebhook(
   subCommand: string | undefined,
   ctx: CommandContext,
   context?: AuthenticatedWebhookContext,
+  extraArgs: string[] = [],
 ) {
   switch (subCommand) {
     case 'listen':
@@ -24,6 +25,7 @@ export async function handleWebhook(
         API_KEY: context.apiKey,
         dodoClient: context.client,
         ctx,
+        endpoint: extraArgs[0],
       });
       break;
     case 'trigger':

--- a/src/commands/webhook/index.ts
+++ b/src/commands/webhook/index.ts
@@ -13,7 +13,7 @@ export async function handleWebhook(
   subCommand: string | undefined,
   ctx: CommandContext,
   context?: AuthenticatedWebhookContext,
-  extraArgs: string[] = [],
+  extraArgs: readonly string[] = [],
 ) {
   switch (subCommand) {
     case 'listen':

--- a/src/commands/webhook/index.ts
+++ b/src/commands/webhook/index.ts
@@ -2,6 +2,7 @@ import type DodoPayments from 'dodopayments';
 import WebhookListener from './listen';
 import { handleWebhookTrigger } from './trigger';
 import type { CommandContext } from '../../tui/CommandContext';
+import { unknownSubcommand } from '../../utils/usage-help';
 
 type AuthenticatedWebhookContext = {
   apiKey: string;
@@ -32,6 +33,6 @@ export async function handleWebhook(
       await handleWebhookTrigger(ctx, extraArgs);
       break;
     default:
-      ctx.addBlock({ type: 'help' });
+      unknownSubcommand(ctx, 'wh', subCommand);
   }
 }

--- a/src/commands/webhook/listen.ts
+++ b/src/commands/webhook/listen.ts
@@ -1,5 +1,6 @@
 import type DodoPayments from 'dodopayments';
 import type { CommandContext } from '../../tui/CommandContext';
+import { HTTP_SCHEME_ERROR, isHttpUrl } from '../../utils/url';
 
 export default async function WebhookListener({
   API_KEY,
@@ -14,8 +15,8 @@ export default async function WebhookListener({
 }) {
   let endpoint: string;
   if (endpointArg) {
-    if (!endpointArg.startsWith('http://') && !endpointArg.startsWith('https://')) {
-      ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+    if (!isHttpUrl(endpointArg)) {
+      ctx.addBlock({ type: 'error', message: HTTP_SCHEME_ERROR });
       return;
     }
     endpoint = endpointArg;
@@ -32,10 +33,10 @@ export default async function WebhookListener({
         });
         return;
       }
-      if (value.startsWith('http://') || value.startsWith('https://')) {
+      if (isHttpUrl(value)) {
         endpoint = value;
       } else {
-        ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+        ctx.addBlock({ type: 'error', message: HTTP_SCHEME_ERROR });
       }
     }
   }

--- a/src/commands/webhook/listen.ts
+++ b/src/commands/webhook/listen.ts
@@ -5,12 +5,27 @@ export default async function WebhookListener({
   API_KEY,
   dodoClient,
   ctx,
+  endpoint: endpointArg,
 }: {
   API_KEY: string;
   dodoClient: DodoPayments;
   ctx: CommandContext;
+  endpoint?: string;
 }) {
-  const endpoint = await ctx.promptInput('Endpoint URL');
+  let endpoint: string;
+  if (endpointArg) {
+    endpoint = endpointArg;
+  } else {
+    try {
+      endpoint = await ctx.promptInput('Endpoint URL');
+    } catch {
+      ctx.addBlock({
+        type: 'error',
+        message: 'Endpoint URL is required. Usage: dodo wh listen <url>',
+      });
+      return;
+    }
+  }
 
   let targetedEndpoint: string;
   if (process.env.DODO_WH_TEST_SERVER_URL) {

--- a/src/commands/webhook/listen.ts
+++ b/src/commands/webhook/listen.ts
@@ -14,16 +14,29 @@ export default async function WebhookListener({
 }) {
   let endpoint: string;
   if (endpointArg) {
+    if (!endpointArg.startsWith('http://') && !endpointArg.startsWith('https://')) {
+      ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+      return;
+    }
     endpoint = endpointArg;
   } else {
-    try {
-      endpoint = await ctx.promptInput('Endpoint URL');
-    } catch {
-      ctx.addBlock({
-        type: 'error',
-        message: 'Endpoint URL is required. Usage: dodo wh listen <url>',
-      });
-      return;
+    endpoint = '';
+    while (!endpoint) {
+      let value: string;
+      try {
+        value = await ctx.promptInput('Endpoint URL');
+      } catch {
+        ctx.addBlock({
+          type: 'error',
+          message: 'Endpoint URL is required. Usage: dodo wh listen <url>',
+        });
+        return;
+      }
+      if (value.startsWith('http://') || value.startsWith('https://')) {
+        endpoint = value;
+      } else {
+        ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+      }
     }
   }
 

--- a/src/commands/webhook/trigger.ts
+++ b/src/commands/webhook/trigger.ts
@@ -4,6 +4,7 @@ import {
   type SupportedEvent,
 } from './functions/supported-events';
 import type { CommandContext } from '../../tui/CommandContext';
+import { HTTP_SCHEME_ERROR, isHttpUrl } from '../../utils/url';
 
 import {
   genSubscriptionActive,
@@ -123,18 +124,20 @@ async function triggerOnce(
     return;
   }
 
-  if (!supportedEvents.includes(eventArg as SupportedEvent)) {
+  if (!(supportedEvents as readonly string[]).includes(eventArg)) {
     ctx.addBlock({ type: 'error', message: `Unsupported event '${eventArg}'.` });
     ctx.addBlock({ type: 'info', message: USAGE });
     return;
   }
+  const event = eventArg as SupportedEvent;
 
-  if (!urlArg.startsWith('http://') && !urlArg.startsWith('https://')) {
-    ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+  if (!isHttpUrl(urlArg)) {
+    ctx.addBlock({ type: 'error', message: HTTP_SCHEME_ERROR });
+    ctx.addBlock({ type: 'info', message: USAGE });
     return;
   }
 
-  await sendEvent(ctx, urlArg, eventArg as SupportedEvent, {
+  await sendEvent(ctx, urlArg, event, {
     business_id: 'bus_test',
     product_id: 'pdt_test',
     metadata: {},
@@ -145,7 +148,7 @@ async function triggerOnce(
 
 export async function handleWebhookTrigger(
   ctx: CommandContext,
-  extraArgs: string[] = [],
+  extraArgs: readonly string[] = [],
 ): Promise<void> {
   const [eventArg, urlArg] = extraArgs;
   if (eventArg || urlArg) {
@@ -163,10 +166,10 @@ export async function handleWebhookTrigger(
       ctx.addBlock({ type: 'info', message: USAGE });
       return;
     }
-    if (value.startsWith('http://') || value.startsWith('https://')) {
+    if (isHttpUrl(value)) {
       endpoint = value;
     } else {
-      ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+      ctx.addBlock({ type: 'error', message: HTTP_SCHEME_ERROR });
     }
   }
 

--- a/src/commands/webhook/trigger.ts
+++ b/src/commands/webhook/trigger.ts
@@ -78,10 +78,91 @@ function parseMetadata(metadataInput: string): Record<string, unknown> {
   }
 }
 
-export async function handleWebhookTrigger(ctx: CommandContext): Promise<void> {
+const USAGE = [
+  'Usage: dodo wh trigger <event> <url>',
+  '',
+  'Supported events:',
+  ...supportedEvents.map((e) => `  ${e}`),
+].join('\n');
+
+async function sendEvent(
+  ctx: CommandContext,
+  endpoint: string,
+  event: SupportedEvent,
+  args: baseArgs,
+): Promise<void> {
+  const data = eventGenerators[event](args);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+    const responseBody = await response.text();
+
+    ctx.addBlock({ type: 'success', message: 'Webhook event sent.' });
+    ctx.addBlock({
+      type: 'detail',
+      data: { Status: response.status, Response: responseBody },
+    });
+  } catch (error: any) {
+    ctx.addBlock({ type: 'error', message: `Webhook event failed. ${error.message}` });
+  }
+}
+
+async function triggerOnce(
+  ctx: CommandContext,
+  eventArg: string | undefined,
+  urlArg: string | undefined,
+): Promise<void> {
+  if (!eventArg || !urlArg) {
+    ctx.addBlock({ type: 'error', message: 'Event and URL are required.' });
+    ctx.addBlock({ type: 'info', message: USAGE });
+    return;
+  }
+
+  if (!supportedEvents.includes(eventArg as SupportedEvent)) {
+    ctx.addBlock({ type: 'error', message: `Unsupported event '${eventArg}'.` });
+    ctx.addBlock({ type: 'info', message: USAGE });
+    return;
+  }
+
+  if (!urlArg.startsWith('http://') && !urlArg.startsWith('https://')) {
+    ctx.addBlock({ type: 'error', message: 'URL must start with http:// or https://' });
+    return;
+  }
+
+  await sendEvent(ctx, urlArg, eventArg as SupportedEvent, {
+    business_id: 'bus_test',
+    product_id: 'pdt_test',
+    metadata: {},
+    email: 'john.doe@example.com',
+    customer_id: 'cus_test',
+  });
+}
+
+export async function handleWebhookTrigger(
+  ctx: CommandContext,
+  extraArgs: string[] = [],
+): Promise<void> {
+  const [eventArg, urlArg] = extraArgs;
+  if (eventArg || urlArg) {
+    await triggerOnce(ctx, eventArg, urlArg);
+    return;
+  }
+
   let endpoint = '';
   while (!endpoint) {
-    const value = await ctx.promptInput('Endpoint URL');
+    let value: string;
+    try {
+      value = await ctx.promptInput('Endpoint URL');
+    } catch {
+      ctx.addBlock({ type: 'error', message: 'Event and URL are required.' });
+      ctx.addBlock({ type: 'info', message: USAGE });
+      return;
+    }
     if (value.startsWith('http://') || value.startsWith('https://')) {
       endpoint = value;
     } else {
@@ -132,36 +213,12 @@ export async function handleWebhookTrigger(ctx: CommandContext): Promise<void> {
       return;
     }
 
-    const generator = eventGenerators[event];
-    const data = generator({
+    await sendEvent(ctx, endpoint, event, {
       business_id: businessId,
       product_id: productId,
       metadata,
       email,
       customer_id: customerId,
     });
-
-    try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      });
-
-      const responseBody = await response.text();
-
-      ctx.addBlock({ type: 'success', message: 'Webhook event sent.' });
-      ctx.addBlock({
-        type: 'detail',
-        data: {
-          'Status': response.status,
-          'Response': responseBody
-        }
-      });
-    } catch (error: any) {
-      ctx.addBlock({ type: 'error', message: `Webhook event failed. ${error.message}` });
-    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,14 @@ if (process.stdout.isTTY && !category) {
   process.on('SIGINT', () => process.exit(0));
   process.on('SIGTERM', () => process.exit(0));
   try {
+    if (category && subCommand) {
+      const { isInteractiveOnly } = await import('./utils/usage-help');
+      if (isInteractiveOnly(category, subCommand)) {
+        console.error(`\`dodo ${category} ${subCommand}\` is interactive — open the TUI with \`dodo\`.`);
+        process.exit(0);
+      }
+    }
+
     if (category === 'login') {
       const { handleLogin } = await import('./commands/login');
       await handleLogin(defaultContext, subCommand, extraArgs[0]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,10 @@ if (process.stdout.isTTY && !category) {
   try {
     if (category === 'login') {
       const { handleLogin } = await import('./commands/login');
-      await handleLogin(defaultContext);
+      await handleLogin(defaultContext, subCommand, extraArgs[0]);
     } else if (category === 'logout') {
       const { handleLogout } = await import('./commands/logout');
-      await handleLogout(defaultContext);
+      await handleLogout(defaultContext, undefined, subCommand);
     } else if (category === 'wh' && subCommand === 'trigger') {
       const { handleWebhook } = await import('./commands/webhook');
       await handleWebhook(subCommand, defaultContext, undefined, extraArgs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,18 +38,15 @@ if (process.stdout.isTTY && !category) {
       const { handleWebhook } = await import('./commands/webhook');
       await handleWebhook(subCommand, defaultContext, undefined, extraArgs);
     } else if (!(await configExists())) {
-      if (category === 'wh' && !subCommand) {
-        renderHelp(category);
-        console.log();
-        console.log(
-          'Run `dodo wh trigger` without logging in, or `dodo login` to use `dodo wh listen`.',
-        );
-        process.exit(0);
-      }
-
       if (category && !subCommand) {
         renderHelp(category);
         console.log();
+        const { categoryNotes } = await import('./utils/usage-help');
+        const note = categoryNotes[category];
+        if (note) {
+          console.log(note);
+          process.exit(0);
+        }
       } else if (!category && !subCommand) {
         renderHelp();
         console.log();

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ if (process.stdout.isTTY && !category) {
         }
         case 'wh': {
           const { handleWebhook } = await import('./commands/webhook');
-          await handleWebhook(subCommand, defaultContext, { apiKey, client: dodoClient });
+          await handleWebhook(subCommand, defaultContext, { apiKey, client: dodoClient }, extraArgs);
           break;
         }
         default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ if (process.stdout.isTTY && !category) {
       await handleLogout(defaultContext);
     } else if (category === 'wh' && subCommand === 'trigger') {
       const { handleWebhook } = await import('./commands/webhook');
-      await handleWebhook(subCommand, defaultContext);
+      await handleWebhook(subCommand, defaultContext, undefined, extraArgs);
     } else if (!(await configExists())) {
       if (category === 'wh' && !subCommand) {
         renderHelp(category);

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -22,6 +22,7 @@ export const COMMANDS = [
   { command: '/ai',               description: 'Ask a question about your data' },
   { command: '/login',            description: 'Login with a Dodo API key' },
   { command: '/logout',           description: 'Logout from stored accounts' },
+  { command: '/switch',           description: 'Switch between Test and Live modes' },
   { command: '/update',           description: 'Update the CLI to the latest version' },
   { command: '/clear',            description: 'Clear message history' },
   { command: '/exit',             description: 'Exit the CLI' },

--- a/src/tui/CommandContext.ts
+++ b/src/tui/CommandContext.ts
@@ -19,6 +19,7 @@ export interface CommandContext {
   promptSelect: (label: string, options: { label: string; value: string }[]) => Promise<string>;
   promptConfirm: (message: string) => Promise<boolean>;
   clear: () => void;
+  readonly invocation: 'tui' | 'cli';
 }
 
 export interface MessageStore {
@@ -134,6 +135,6 @@ export const createMessageStore = (): MessageStore => {
     messages,
     setMessages,
     pushUserEcho,
-    ctx: { addBlock, updateBlock, removeBlock, promptInput, promptSelect, promptConfirm, clear },
+    ctx: { addBlock, updateBlock, removeBlock, promptInput, promptSelect, promptConfirm, clear, invocation: 'tui' },
   };
 };

--- a/src/tui/DefaultContext.ts
+++ b/src/tui/DefaultContext.ts
@@ -7,6 +7,7 @@
 
 import type { CommandContext } from './CommandContext';
 import type { BlockVariant } from './types';
+import { renderHelp } from '../ui/help';
 
 export const defaultContext: CommandContext = {
   addBlock: (b: BlockVariant) => {
@@ -20,7 +21,7 @@ export const defaultContext: CommandContext = {
     else if (b.type === 'markdown') console.log(b.text);
     else if (b.type === 'event') console.log(b.event);
     else if (b.type === 'empty') console.log('No results found.');
-    else if (b.type === 'help') console.log('Commands...');
+    else if (b.type === 'help') renderHelp();
     return '';
   },
   updateBlock: () => {},

--- a/src/tui/DefaultContext.ts
+++ b/src/tui/DefaultContext.ts
@@ -36,4 +36,5 @@ export const defaultContext: CommandContext = {
     throw new Error('Cannot prompt in non-TTY mode');
   },
   clear: () => console.clear(),
+  invocation: 'cli',
 };

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -52,7 +52,7 @@ const App = () => {
   });
   const palettePool = createMemo(() => rankCommands(input()));
 
-  onMount(() => {
+  const refreshAuthInfo = () => {
     resolveCredentials(undefined, false)
       .then(({ mode, apiKey }) => {
         setSessionMode(mode);
@@ -60,6 +60,10 @@ const App = () => {
         setAuthInfo({ mode, key: masked });
       })
       .catch(() => setAuthInfo(null));
+  };
+
+  onMount(() => {
+    refreshAuthInfo();
 
     const completed = consumePendingSilentUpdate();
     if (completed && completed.to !== completed.from) {
@@ -116,7 +120,7 @@ const App = () => {
     setPaletteDismissed(false);
     setIsProcessing(true);
     try {
-      await handleCommand(trimmed, store.ctx, exitTui);
+      await handleCommand(trimmed, store.ctx, exitTui, refreshAuthInfo);
     } catch (e: any) {
       store.ctx.addBlock({
         type: 'error',

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -138,7 +138,6 @@ const App = () => {
     // before destroy() flips stdin to canonical mode and the kernel echoes them.
     setTimeout(() => {
       renderer.destroy();
-      process.stdout.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?25h');
       process.exit(0);
     }, 80);
   };
@@ -260,5 +259,10 @@ const App = () => {
 };
 
 export const mountTuiApp = (): void => {
+  // Restore terminal state on any exit, including OpenTUI's own Ctrl+C handler
+  // (which bypasses exitTui).
+  process.on('exit', () => {
+    process.stdout.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?25h');
+  });
   render(() => <App />, { exitOnCtrlC: true, targetFps: 30, useMouse: true });
 };

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -132,6 +132,17 @@ const App = () => {
   };
 
   const renderer = useRenderer();
+
+  const exitTui = () => {
+    // Defer to let OpenTUI's stdin parser drain in-flight terminal responses
+    // before destroy() flips stdin to canonical mode and the kernel echoes them.
+    setTimeout(() => {
+      renderer.destroy();
+      process.stdout.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?25h');
+      process.exit(0);
+    }, 80);
+  };
+
   useSelectionHandler((selection) => {
     const text = selection.getSelectedText();
     if (!text || text.trim().length === 0) return;
@@ -246,12 +257,6 @@ const App = () => {
       </box>
     </TuiContextProvider>
   );
-};
-
-const exitTui = () => {
-  // Disable mouse tracking (1000, 1002, 1003, 1006, 1015) and show cursor
-  process.stdout.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?25h');
-  process.exit(0);
 };
 
 export const mountTuiApp = (): void => {

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -66,7 +66,7 @@ export const InputBar = (props: InputBarProps) => {
             {(info: () => NonNullable<AuthInfo>) => (
               <>
                 <text fg={info().mode === 'test_mode' ? colors.testMode : colors.liveMode}>
-                  {info().mode === 'test_mode' ? 'TEST' : 'LIVE'}
+                  {info().mode === 'test_mode' ? 'TEST MODE' : 'LIVE MODE'}
                 </text>
                 <text fg={colors.textDim}>{` ${glyphs.separator} `}</text>
                 <text fg={colors.textMuted}>{info().key}</text>

--- a/src/tui/help-structure.ts
+++ b/src/tui/help-structure.ts
@@ -86,6 +86,7 @@ export const HELP_GROUPS: HelpGroup[] = [
     items: [
       { command: '/login', description: 'Sign in with a Dodo Payments API key' },
       { command: '/logout', description: 'Sign out from stored accounts' },
+      { command: '/switch', description: 'Toggle between Test and Live modes' },
     ],
   },
   {

--- a/src/tui/router.ts
+++ b/src/tui/router.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CommandContext } from './CommandContext';
-import { resolveCredentials } from '../utils/auth';
+import { resolveCredentials, clearSessionMode } from '../utils/auth';
 
 export async function handleCommand(
   input: string,
@@ -58,6 +58,13 @@ export async function handleCommand(
   if (cmd === '/logout') {
     const { handleLogout } = await import('../commands/logout');
     await handleLogout(ctx, exit);
+    return;
+  }
+
+  if (cmd === '/switch') {
+    await resolveCredentials(ctx, true, true);
+    refreshAuth();
+    ctx.addBlock({ type: 'success', message: 'Environment switched.' });
     return;
   }
 

--- a/src/tui/router.ts
+++ b/src/tui/router.ts
@@ -119,7 +119,7 @@ export async function handleCommand(
     }
     case '/wh': {
       const { handleWebhook } = await import('../commands/webhook');
-      await handleWebhook(subCmd, ctx, { apiKey, client });
+      await handleWebhook(subCmd, ctx, { apiKey, client }, extraArgs);
       break;
     }
     case '/clear': {

--- a/src/tui/router.ts
+++ b/src/tui/router.ts
@@ -8,7 +8,12 @@
 import type { CommandContext } from './CommandContext';
 import { resolveCredentials } from '../utils/auth';
 
-export async function handleCommand(input: string, ctx: CommandContext, exit: () => void) {
+export async function handleCommand(
+  input: string,
+  ctx: CommandContext,
+  exit: () => void,
+  refreshAuth: () => void,
+) {
   const trimmedInput = input.trim();
   if (!trimmedInput) return;
 
@@ -47,6 +52,7 @@ export async function handleCommand(input: string, ctx: CommandContext, exit: ()
   if (cmd === '/login') {
     const { handleLogin } = await import('../commands/login');
     await handleLogin(ctx);
+    refreshAuth();
     return;
   }
 

--- a/src/tui/router.ts
+++ b/src/tui/router.ts
@@ -51,8 +51,7 @@ export async function handleCommand(
 
   if (cmd === '/login') {
     const { handleLogin } = await import('../commands/login');
-    await handleLogin(ctx);
-    refreshAuth();
+    if (await handleLogin(ctx)) refreshAuth();
     return;
   }
 

--- a/src/tui/router.ts
+++ b/src/tui/router.ts
@@ -58,7 +58,7 @@ export async function handleCommand(
 
   if (cmd === '/logout') {
     const { handleLogout } = await import('../commands/logout');
-    await handleLogout(ctx);
+    await handleLogout(ctx, exit);
     return;
   }
 

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -8,9 +8,10 @@ export const renderHelp = (category?: string): void => {
     const commands = usage[category as keyof typeof usage]!;
 
     console.log(category);
-    commands.forEach(({ command, description }, index) => {
+    commands.forEach(({ command, description, interactive }, index) => {
       const prefix = index === commands.length - 1 ? '`--' : '|--';
-      console.log(`${prefix} dodo ${category} ${command} - ${description}`);
+      const tag = interactive ? ' (TUI only)' : '';
+      console.log(`${prefix} dodo ${category} ${command} - ${description}${tag}`);
     });
 
     return;
@@ -30,12 +31,13 @@ export const renderHelp = (category?: string): void => {
 
     console.log(`${isLastCategory ? '`--' : '|--'} ${categoryName}`);
 
-    commands.forEach(({ command, description }, commandIndex) => {
+    commands.forEach(({ command, description, interactive }, commandIndex) => {
       const prefix = isLastCategory ? '    ' : '|   ';
       const branch = commandIndex === commands.length - 1 ? '`--' : '|--';
+      const tag = interactive ? ' (TUI only)' : '';
 
       console.log(
-        `${prefix}${branch} dodo ${categoryName} ${command} - ${description}`,
+        `${prefix}${branch} dodo ${categoryName} ${command} - ${description}${tag}`,
       );
     });
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -14,6 +14,7 @@ export type LogoutTarget = Mode | 'all';
 
 const CONFIG_DIR = path.join(os.homedir(), '.dodopayments');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const STATE_PATH = path.join(CONFIG_DIR, 'state.json');
 const LEGACY_CONFIG_PATH = path.join(CONFIG_DIR, 'api-key');
 const ALL_MODES: Mode[] = ['test_mode', 'live_mode'];
 const ALGORITHM = 'aes-256-gcm';
@@ -21,12 +22,44 @@ const ALGORITHM = 'aes-256-gcm';
 let sessionMode: Mode | null = null;
 let cachedKey: Buffer | null = null;
 
+export type State = {
+  mode?: Mode;
+};
+
+function readState(): State {
+  try {
+    if (fs.existsSync(STATE_PATH)) {
+      return JSON.parse(fs.readFileSync(STATE_PATH, 'utf-8'));
+    }
+  } catch {
+    // Ignore errors
+  }
+  return {};
+}
+
+function writeState(state: State) {
+  ensureConfigDir();
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
 export function setSessionMode(mode: Mode) {
   sessionMode = mode;
+  writeState({ mode });
 }
 
 export function getSessionMode(): Mode | null {
+  if (!sessionMode) {
+    const state = readState();
+    if (state.mode) {
+      sessionMode = state.mode;
+    }
+  }
   return sessionMode;
+}
+
+export function clearSessionMode() {
+  sessionMode = null;
+  writeState({});
 }
 
 function getEncryptionKey(): Buffer {
@@ -192,6 +225,7 @@ export async function resetConfig(): Promise<void> {
       // Ignore errors
     }
   }
+  clearSessionMode();
 }
 
 export async function clearConfig(target: LogoutTarget): Promise<{
@@ -214,6 +248,7 @@ export async function clearConfig(target: LogoutTarget): Promise<{
 
   if (target === 'all') {
     await resetConfig();
+    clearSessionMode();
     return { hadInvalidConfig: false, removedModes: configuredModes };
   }
 
@@ -226,15 +261,34 @@ export async function clearConfig(target: LogoutTarget): Promise<{
   delete config[target];
   await writeConfig(config);
 
+  if (sessionMode === target) {
+    clearSessionMode();
+  }
+
   return { hadInvalidConfig: false, removedModes: [target] };
 }
 
 import type { CommandContext } from '../tui/CommandContext';
 
-export async function resolveCredentials(ctx?: CommandContext, prompt: boolean = true): Promise<ResolvedCredentials> {
-  if (sessionMode) {
+export async function resolveCredentials(
+  ctx?: CommandContext,
+  prompt: boolean = true,
+  forcePrompt: boolean = false,
+): Promise<ResolvedCredentials> {
+  if (!sessionMode) {
+    const state = readState();
+    if (state.mode) {
+      sessionMode = state.mode;
+    }
+  }
+
+  if (sessionMode && !forcePrompt) {
     const config = await readConfig();
-    return { mode: sessionMode, apiKey: config[sessionMode]! };
+    // If the persisted mode is no longer in config, we should ignore it
+    if (config[sessionMode]) {
+      return { mode: sessionMode, apiKey: config[sessionMode]! };
+    }
+    sessionMode = null;
   }
 
   if (!(await configExists())) {
@@ -256,8 +310,9 @@ export async function resolveCredentials(ctx?: CommandContext, prompt: boolean =
     throw new Error('No valid credentials. Run /login to retry.');
   }
 
-  if (modes.length === 1 || !prompt) {
+  if (modes.length === 1 || (!prompt && !forcePrompt)) {
     const mode = modes[0] as Mode;
+    if (prompt) setSessionMode(mode);
     return { mode, apiKey: config[mode]! };
   }
 
@@ -265,10 +320,14 @@ export async function resolveCredentials(ctx?: CommandContext, prompt: boolean =
     throw new Error('Multiple environments configured. Run the CLI without arguments to choose one.');
   }
 
-  const selectedMode = await ctx.promptSelect('Environment', modes.map((mode) => ({
-    label: mode === 'test_mode' ? 'Test Mode' : 'Live Mode',
-    value: mode,
-  }))) as Mode;
+  const selectedMode = (await ctx.promptSelect(
+    'Environment',
+    modes.map((mode) => ({
+      label: mode === 'test_mode' ? 'Test Mode' : 'Live Mode',
+      value: mode,
+    })),
+  )) as Mode;
 
+  setSessionMode(selectedMode);
   return { mode: selectedMode, apiKey: config[selectedMode]! };
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -53,10 +53,11 @@ function encrypt(text: string): string {
 function decrypt(text: string): string {
   const parts = text.split(':');
   if (parts.length !== 3) throw new Error('Invalid encrypted format');
-  const iv = Buffer.from(parts[0], 'hex');
-  const authTag = Buffer.from(parts[1], 'hex');
-  const encrypted = parts[2];
-  
+  const [ivHex, tagHex, encrypted] = parts;
+  if (!ivHex || !tagHex || !encrypted) throw new Error('Invalid encrypted format');
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(tagHex, 'hex');
+
   const decipher = crypto.createDecipheriv(ALGORITHM, getEncryptionKey(), iv);
   decipher.setAuthTag(authTag);
   let decrypted = decipher.update(encrypted, 'hex', 'utf8');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,8 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import keytar from 'keytar';
+import crypto from 'node:crypto';
+import { machineIdSync } from 'node-machine-id';
 
 export type Mode = 'test_mode' | 'live_mode';
 export type Config = Partial<Record<Mode, string>>;
@@ -11,12 +12,14 @@ export type ResolvedCredentials = {
 };
 export type LogoutTarget = Mode | 'all';
 
-const SERVICE_NAME = 'dodopayments-cli';
 const CONFIG_DIR = path.join(os.homedir(), '.dodopayments');
-const CONFIG_PATH = path.join(CONFIG_DIR, 'api-key');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const LEGACY_CONFIG_PATH = path.join(CONFIG_DIR, 'api-key');
 const ALL_MODES: Mode[] = ['test_mode', 'live_mode'];
+const ALGORITHM = 'aes-256-gcm';
 
 let sessionMode: Mode | null = null;
+let cachedKey: Buffer | null = null;
 
 export function setSessionMode(mode: Mode) {
   sessionMode = mode;
@@ -26,21 +29,62 @@ export function getSessionMode(): Mode | null {
   return sessionMode;
 }
 
+function getEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  let id: string;
+  try {
+    id = machineIdSync();
+  } catch {
+    id = `${os.hostname()}-${os.userInfo().username}`;
+  }
+  cachedKey = crypto.pbkdf2Sync(id, 'dodopayments-cli-salt', 100000, 32, 'sha256');
+  return cachedKey;
+}
+
+function encrypt(text: string): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, getEncryptionKey(), iv);
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const authTag = cipher.getAuthTag().toString('hex');
+  return `${iv.toString('hex')}:${authTag}:${encrypted}`;
+}
+
+function decrypt(text: string): string {
+  const parts = text.split(':');
+  if (parts.length !== 3) throw new Error('Invalid encrypted format');
+  const iv = Buffer.from(parts[0], 'hex');
+  const authTag = Buffer.from(parts[1], 'hex');
+  const encrypted = parts[2];
+  
+  const decipher = crypto.createDecipheriv(ALGORITHM, getEncryptionKey(), iv);
+  decipher.setAuthTag(authTag);
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+
+function ensureConfigDir() {
+  if (!fs.existsSync(CONFIG_DIR)) {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
 async function migrate(): Promise<void> {
-  if (fs.existsSync(CONFIG_PATH)) {
+  // Try to migrate from legacy api-key file if config.json doesn't exist
+  if (!fs.existsSync(CONFIG_PATH) && fs.existsSync(LEGACY_CONFIG_PATH)) {
     try {
-      const content = fs.readFileSync(CONFIG_PATH, 'utf-8');
-      const config = JSON.parse(content) as Config;
-      for (const mode of ALL_MODES) {
-        const apiKey = config[mode];
-        if (apiKey) {
-          await keytar.setPassword(SERVICE_NAME, mode, apiKey);
-        }
-      }
+      const content = fs.readFileSync(LEGACY_CONFIG_PATH, 'utf-8');
+      const legacyConfig = JSON.parse(content) as Config;
+      await writeConfig(legacyConfig);
     } catch {
       // Ignore migration errors
     } finally {
-      fs.rmSync(CONFIG_PATH, { force: true });
+      try {
+        fs.rmSync(LEGACY_CONFIG_PATH, { force: true });
+      } catch {
+        // Ignore rm errors
+      }
     }
   }
 }
@@ -53,6 +97,8 @@ function getConfiguredModesFromConfig(config: Config): Mode[] {
 }
 
 async function writeConfig(config: Config): Promise<void> {
+  ensureConfigDir();
+  
   const configuredModes = getConfiguredModesFromConfig(config);
 
   if (configuredModes.length === 0) {
@@ -60,43 +106,66 @@ async function writeConfig(config: Config): Promise<void> {
     return;
   }
 
-  for (const mode of ALL_MODES) {
-    const apiKey = config[mode];
-    if (apiKey) {
-      await keytar.setPassword(SERVICE_NAME, mode, apiKey);
-    } else {
-      await keytar.deletePassword(SERVICE_NAME, mode);
-    }
+  // Filter config to only include configured modes
+  const filteredConfig: Config = {};
+  for (const mode of configuredModes) {
+    filteredConfig[mode] = config[mode];
   }
-}
 
-export async function configExists(): Promise<boolean> {
-  await migrate();
-  for (const mode of ALL_MODES) {
-    const password = await keytar.getPassword(SERVICE_NAME, mode);
-    if (password) return true;
+  const jsonStr = JSON.stringify(filteredConfig, null, 2);
+  const encrypted = encrypt(jsonStr);
+
+  fs.writeFileSync(CONFIG_PATH, encrypted, { mode: 0o600 });
+  
+  try {
+    // Ensure permissions are strictly 0o600 even if the file already existed
+    fs.chmodSync(CONFIG_PATH, 0o600);
+  } catch {
+    // Ignore if chmod fails (e.g. on Windows)
   }
-  return false;
 }
 
 export async function readConfig(): Promise<Config> {
   await migrate();
-  const config: Config = {};
-  let hasAny = false;
+  if (!fs.existsSync(CONFIG_PATH)) {
+    throw new Error('CONFIG_NOT_FOUND');
+  }
 
-  for (const mode of ALL_MODES) {
-    const password = await keytar.getPassword(SERVICE_NAME, mode);
-    if (password) {
-      config[mode] = password;
-      hasAny = true;
+  const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+  let config: Config;
+
+  try {
+    // Try to decrypt
+    const decrypted = decrypt(raw);
+    config = JSON.parse(decrypted) as Config;
+  } catch (err) {
+    // If decryption fails, it might be in plaintext (from a previous version)
+    try {
+      config = JSON.parse(raw) as Config;
+      // Re-save as encrypted
+      await writeConfig(config);
+    } catch {
+      throw new Error('CONFIG_NOT_FOUND');
     }
   }
 
-  if (!hasAny) {
+  if (getConfiguredModesFromConfig(config).length === 0) {
     throw new Error('CONFIG_NOT_FOUND');
   }
 
   return config;
+}
+
+export async function configExists(): Promise<boolean> {
+  await migrate();
+  if (!fs.existsSync(CONFIG_PATH)) return false;
+  
+  try {
+    const config = await readConfig();
+    return getConfiguredModesFromConfig(config).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 export async function saveConfig(mode: Mode, apiKey: string): Promise<void> {
@@ -115,8 +184,12 @@ export async function saveConfig(mode: Mode, apiKey: string): Promise<void> {
 }
 
 export async function resetConfig(): Promise<void> {
-  for (const mode of ALL_MODES) {
-    await keytar.deletePassword(SERVICE_NAME, mode);
+  if (fs.existsSync(CONFIG_PATH)) {
+    try {
+      fs.unlinkSync(CONFIG_PATH);
+    } catch {
+      // Ignore errors
+    }
   }
 }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,5 @@
+export const HTTP_SCHEME_ERROR = 'URL must start with http:// or https://';
+
+export function isHttpUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://');
+}

--- a/src/utils/usage-help.ts
+++ b/src/utils/usage-help.ts
@@ -57,26 +57,37 @@ export const usage: Record<string, UsageCommand[]> = {
   checkout: [{ command: 'new', description: 'Create a checkout session' }],
 };
 
+export const categoryNotes: Record<string, string> = {
+  wh: 'Run `dodo wh trigger` without logging in, or `dodo login` to use `dodo wh listen`.',
+};
+
 export function unknownSubcommand(
   ctx: CommandContext,
   category: string,
   subCommand: string | undefined,
 ): void {
+  const invocation = ctx.invocation === 'cli' ? `dodo ${category}` : `/${category}`;
+
   if (subCommand) {
     ctx.addBlock({
       type: 'error',
-      message: `Unknown subcommand '${subCommand}' for /${category}.`,
+      message: `Unknown subcommand '${subCommand}' for ${invocation}.`,
     });
   } else {
-    ctx.addBlock({ type: 'error', message: `Subcommand required for /${category}.` });
+    ctx.addBlock({ type: 'error', message: `Subcommand required for ${invocation}.` });
   }
 
   const commands = usage[category];
-  if (!commands) return;
+  if (commands) {
+    const lines = [
+      'Usage:',
+      ...commands.map((c) => `  ${invocation} ${c.command} - ${c.description}`),
+    ].join('\n');
+    ctx.addBlock({ type: 'info', message: lines });
+  }
 
-  const lines = [
-    'Usage:',
-    ...commands.map((c) => `  /${category} ${c.command} - ${c.description}`),
-  ].join('\n');
-  ctx.addBlock({ type: 'info', message: lines });
+  const note = categoryNotes[category];
+  if (note && ctx.invocation === 'cli') {
+    ctx.addBlock({ type: 'info', message: note });
+  }
 }

--- a/src/utils/usage-help.ts
+++ b/src/utils/usage-help.ts
@@ -3,6 +3,7 @@ import type { CommandContext } from '../tui/CommandContext';
 type UsageCommand = {
   command: string;
   description: string;
+  interactive?: boolean;
 };
 
 // For help commands
@@ -29,13 +30,13 @@ export const usage: Record<string, UsageCommand[]> = {
   ],
   customers: [
     { command: 'list', description: 'List your customers' },
-    { command: 'create', description: 'Create a customer' },
-    { command: 'update <id>', description: 'Update a customer' },
+    { command: 'create', description: 'Create a customer', interactive: true },
+    { command: 'update <id>', description: 'Update a customer', interactive: true },
   ],
   discounts: [
     { command: 'list', description: 'List your discounts' },
-    { command: 'create', description: 'Create a discount' },
-    { command: 'delete <id>', description: 'Remove a discount' },
+    { command: 'create', description: 'Create a discount', interactive: true },
+    { command: 'delete <id>', description: 'Remove a discount', interactive: true },
   ],
   licences: [{ command: 'list', description: 'List licences' }],
   addons: [
@@ -54,8 +55,14 @@ export const usage: Record<string, UsageCommand[]> = {
     },
     { command: 'trigger <event> <url>', description: 'Trigger a webhook event offline' },
   ],
-  checkout: [{ command: 'new', description: 'Create a checkout session' }],
+  checkout: [{ command: 'new', description: 'Create a checkout session', interactive: true }],
 };
+
+export function isInteractiveOnly(category: string, subCommand: string): boolean {
+  const commands = usage[category];
+  if (!commands) return false;
+  return commands.some((c) => c.command.split(' ')[0] === subCommand && c.interactive === true);
+}
 
 export const categoryNotes: Record<string, string> = {
   wh: 'Run `dodo wh trigger` without logging in, or `dodo login` to use `dodo wh listen`.',
@@ -79,9 +86,13 @@ export function unknownSubcommand(
 
   const commands = usage[category];
   if (commands) {
+    const annotate = ctx.invocation === 'cli';
     const lines = [
       'Usage:',
-      ...commands.map((c) => `  ${invocation} ${c.command} - ${c.description}`),
+      ...commands.map((c) => {
+        const tag = annotate && c.interactive ? ' (TUI only)' : '';
+        return `  ${invocation} ${c.command} - ${c.description}${tag}`;
+      }),
     ].join('\n');
     ctx.addBlock({ type: 'info', message: lines });
   }

--- a/src/utils/usage-help.ts
+++ b/src/utils/usage-help.ts
@@ -1,3 +1,5 @@
+import type { CommandContext } from '../tui/CommandContext';
+
 type UsageCommand = {
   command: string;
   description: string;
@@ -54,3 +56,27 @@ export const usage: Record<string, UsageCommand[]> = {
   ],
   checkout: [{ command: 'new', description: 'Create a checkout session' }],
 };
+
+export function unknownSubcommand(
+  ctx: CommandContext,
+  category: string,
+  subCommand: string | undefined,
+): void {
+  if (subCommand) {
+    ctx.addBlock({
+      type: 'error',
+      message: `Unknown subcommand '${subCommand}' for /${category}.`,
+    });
+  } else {
+    ctx.addBlock({ type: 'error', message: `Subcommand required for /${category}.` });
+  }
+
+  const commands = usage[category];
+  if (!commands) return;
+
+  const lines = [
+    'Usage:',
+    ...commands.map((c) => `  /${category} ${c.command} - ${c.description}`),
+  ].join('\n');
+  ctx.addBlock({ type: 'info', message: lines });
+}

--- a/src/utils/usage-help.ts
+++ b/src/utils/usage-help.ts
@@ -50,7 +50,7 @@ export const usage: Record<string, UsageCommand[]> = {
       command: 'listen <url>',
       description: 'Listen to webhook events directly from Dodo Payments',
     },
-    { command: 'trigger', description: 'Trigger a webhook event offline' },
+    { command: 'trigger <event> <url>', description: 'Trigger a webhook event offline' },
   ],
   checkout: [{ command: 'new', description: 'Create a checkout session' }],
 };

--- a/src/utils/usage-help.ts
+++ b/src/utils/usage-help.ts
@@ -47,7 +47,7 @@ export const usage: Record<string, UsageCommand[]> = {
   ],
   wh: [
     {
-      command: 'listen',
+      command: 'listen <url>',
       description: 'Listen to webhook events directly from Dodo Payments',
     },
     { command: 'trigger', description: 'Trigger a webhook event offline' },


### PR DESCRIPTION
## Description

- Fix input bar staying on "signed out" after `/login` until the TUI is relaunched.
- Fix terminal residue after exit; `/logout`, `/exit`, double-Esc, and `Ctrl+C` now leave the parent shell clean (mouse-tracking, OSC color queries, kitty keyboard responses).
- Fix headless crashes on `dodo wh listen`, `dodo wh trigger`, `dodo login`, and `dodo logout`; each now accepts positional args with validation.
- Fix unknown subcommands printing the literal `Commands...`; every category now surfaces a clear error plus per-category usage, with `(TUI only)` annotations for interactive subcommands.
- Indicate TUI only commands in docs and usage errors/help guides.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Fixes #123" or "Closes #123" to automatically close the issue when merged -->

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New CLI command
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

<!-- Describe the changes in detail -->

- **TUI auth bar refresh on `/login`** — `handleLogin` returns `Promise<boolean>`; the TUI router only runs `refreshAuthInfo` when login resolves to `true`, preventing a failed auth from flickering the bar to prior credentials.
- **TUI exit cleanup** — `handleLogout` takes an optional `exit` callback and routes every termination through it (including the previously-missed single-mode success path). `exitTui` lives inside the App component, calls `renderer.destroy()`, and defers via `setTimeout(..., 80)` to let OpenTUI's stdin parser drain in-flight terminal responses before destroy flips stdin to canonical mode and the kernel echoes them. A `process.on('exit')` hook in `mountTuiApp` writes the mouse-disable / cursor-show bytes for paths that bypass `exitTui` — notably OpenTUI's own `Ctrl+C` handler.
- **`wh listen` and `wh trigger` headless** — both commands accept positional args (`<url>` and `<event> <url>` respectively); the TUI wizards remain unchanged. Validation: URL scheme (`http`/`https`) and `wh trigger` event against `supportedEvents`. All error paths (missing args, bad event, bad URL) emit the same `error` + `info` USAGE shape for consistency.
- **`dodo login <api-key> <test|live>` and `dodo logout <test|live|all>`** — same class of crash as the webhook commands (interactive prompts hit in non-TUI mode); both gate on `ctx.invocation === 'cli'` and accept positional args. TUI flows for `/login` and `/logout` are untouched.
- **Unknown subcommand UX** — new `unknownSubcommand(ctx, category, subCommand)` helper in `usage-help.ts` emits an `error` block plus an `info` block listing valid subcommands; uses `ctx.invocation` (`'tui' | 'cli'`, added to `CommandContext`) to render `/customers` vs `dodo customers` prefixes. Every command handler's default case across all 9 categories routes through it. A `categoryNotes` map provides per-category hints (e.g. the `wh` "can run offline" note), consumed by both `unknownSubcommand` in CLI mode and `src/index.ts`'s logged-out branch. The `'Commands...'` stub in `DefaultContext.ts` now calls the existing `renderHelp()` as secondary cleanup.
- **Interactive-only command discovery** — subcommands tagged with `interactive: true` in `usage-help.ts` (`customers create`, `customers update`, `discounts create`, `discounts delete`, `checkout new`). The usage list in both `unknownSubcommand` (CLI mode) and `renderHelp` annotates them with `(TUI only)`. `src/index.ts` short-circuits these before the auth gate via `isInteractiveOnly`, giving users an immediate "open the TUI with `dodo`" message rather than a login detour.
- **Refactors** — extracted `isHttpUrl` + `HTTP_SCHEME_ERROR` into `src/utils/url.ts` (consumed in 4 sites across `listen.ts` and `trigger.ts`); widened `supportedEvents` to `readonly string[]` for the `.includes()` check and narrowed the arg afterward; marked `extraArgs: readonly string[]` on `handleWebhook` and `handleWebhookTrigger`.
- **Docs** — README updated to show `/wh listen <url>` and `/wh trigger <event> <url>` syntax with a note clarifying TUI wizard vs direct-mode args.


## Testing

<!-- Describe how you tested your changes -->

### Test Environment

- Runtime (Bun) version: 1.3.13
- OS: macOS

### Test Cases

<!-- List the test cases you've verified -->

- [x] Tested in test mode
- [ ] Tested in live mode (if applicable)
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Other: <!-- specify -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's coding guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] I have tested my changes locally with `bun run index.ts`
- [x] The build passes with `bun run build`

## Screenshots (if applicable)

<!-- Add screenshots or terminal output to help explain your changes -->

## Additional Notes

<!-- Add any additional context or notes for reviewers -->
